### PR TITLE
streamline variable naming

### DIFF
--- a/examples/ModbusRTUSlave32Example/ModbusRTUSlave32Example.ino
+++ b/examples/ModbusRTUSlave32Example/ModbusRTUSlave32Example.ino
@@ -46,10 +46,10 @@ bool& inp_bool_1 = coils[0];
 bool& inp_bool_2 = coils[1];
 bool& out_bool_1 = discretes[0];
 bool& out_bool_2 = discretes[0];
-int32_t& inp_int = holdings[0]._int;
-float& inp_float = holdings[1]._float;
-int32_t& out_int = inputs[0]._int;
-float& out_float = inputs[1]._float;
+int32_t& inp_int = holdings[0].INT32;
+float& inp_float = holdings[1].FLOAT32;
+int32_t& out_int = inputs[0].INT32;
+float& out_float = inputs[1].FLOAT32;
 
 // for Arduino Nano ESP32, modify this line according to ModbusRTUSlaveExample for other boards
 ModbusRTUSlave32 modbus(Serial1, dePin);

--- a/examples/ModbusRTUSlave64Example/ModbusRTUSlave64Example.ino
+++ b/examples/ModbusRTUSlave64Example/ModbusRTUSlave64Example.ino
@@ -49,10 +49,10 @@ bool& inp_bool_1 = coils[0];
 bool& inp_bool_2 = coils[1];
 bool& out_bool_1 = discretes[0];
 bool& out_bool_2 = discretes[0];
-int64_t& inp_long = holdings[0]._long;
-double& inp_double = holdings[1]._double;
-int64_t& out_long = inputs[0]._long;
-double& out_double = inputs[1]._double;
+int64_t& inp_long = holdings[0].INT64;
+double& inp_double = holdings[1].FLOAT64;
+int64_t& out_long = inputs[0].INT64;
+double& out_double = inputs[1].FLOAT64;
 
 // for Arduino Nano ESP32, modify this line according to ModbusRTUSlaveExample for other boards
 ModbusRTUSlave64 modbus(Serial1, dePin);

--- a/src/ModbusRTUSlaveMulti.h
+++ b/src/ModbusRTUSlaveMulti.h
@@ -14,18 +14,18 @@
 // and 4 registers of 16bit to 64bit int/float
 union modbus32 {
     uint16_t reg[2];
-    int32_t _int;
-    float _float;
-    operator int32_t() const {return _int;}
-    operator float() const {return _float;}
+    int32_t INT32;
+    float FLOAT32;
+    operator int32_t() const {return INT32;}
+    operator float() const {return FLOAT32;}
 };
 
 union modbus64 {
     uint16_t reg[4];
-    int64_t _long;
-    double _double;
-    operator int64_t() const {return _long;}
-    operator double() const {return _double;}
+    int64_t INT64;
+    double FLOAT64;
+    operator int64_t() const {return INT64;}
+    operator double() const {return FLOAT64;}
 };
 // ---
 


### PR DESCRIPTION
Streamline naming from _int/_long/_float/_double to INT32/INT64/FLOAT32/FLOAT64